### PR TITLE
Added Chinese simplified translation

### DIFF
--- a/ModMyFactory/ModMyFactory/Lang/Strings.cn.xaml
+++ b/ModMyFactory/ModMyFactory/Lang/Strings.cn.xaml
@@ -1,0 +1,424 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib"
+                    xml:space="preserve">
+    <!--
+    Newline character: &#x0a;
+    -->
+
+
+
+    <sys:String x:Key="NewModpackName">新模组包</sys:String>
+    <sys:String x:Key="LatestFactorioName">最新已安装版本</sys:String>
+
+
+
+    <!--
+    ____________________ Dialogs ____________________
+    -->
+
+    <!-- messages -->
+    <sys:String x:Key="Error.InternetConnection.Message">你的网络有一些问题。&#x0a;请确保你的电脑有稳定的网络之后重试。</sys:String>
+    <sys:String x:Key="Error.InternetConnection.Title">网络问题！</sys:String>
+
+    <sys:String x:Key="Information.32Bit.Message">你使用的Windows是32位的。你将无法玩异星工厂0.15以上版本。</sys:String>
+    <sys:String x:Key="Information.32Bit.Title">检测到32位系统</sys:String>
+
+    <sys:String x:Key="Information.ModExistsPerVersion.Message">异星工厂{1}里模组'{0}'已经存在！</sys:String>
+    <sys:String x:Key="Information.ModExistsPerVersion.Title">跳过模组</sys:String>
+
+    <sys:String x:Key="Information.ModExists.Message">模组'{0}'已经存在！</sys:String>
+    <sys:String x:Key="Information.ModExists.Title">跳过模组</sys:String>
+
+    <sys:String x:Key="Error.InvalidModArchive.Message">ZIP压缩包'{0}'不包含有效的模组。</sys:String>
+    <sys:String x:Key="Error.InvalidModArchive.Title">模组加载错误！</sys:String>
+
+    <sys:String x:Key="Error.InvalidModFolder.Message">此文件夹不包含有效的模组。</sys:String>
+    <sys:String x:Key="Error.InvalidModFolder.Title">模组加载错误！</sys:String>
+
+    <sys:String x:Key="Information.NoModUpdates.Message">所有模组已升级到最新。</sys:String>
+    <sys:String x:Key="Information.NoModUpdates.Title">未找到更新</sys:String>
+    
+    <sys:String x:Key="Question.MoveDirectories.Message">你要将旧文件夹的所有内容转移到新文件夹吗？</sys:String>
+    <sys:String x:Key="Question.MoveDirectories.Title">内容转移？</sys:String>
+
+    <sys:String x:Key="Warning.HasConflicts.Message">导入模组包时发生下列冲突：</sys:String>
+    <sys:String x:Key="Warning.HasConflicts.Title">模组包冲突</sys:String>
+
+    <sys:String x:Key="Question.Update.Message">你正在使用一个旧版的ModMyFactory（目前版本为{0}，最新版本为{1}）。&#x0a;你想要下载最新的ModMyFactory吗？</sys:String>
+    <sys:String x:Key="Question.Update.Title">有可用更新</sys:String>
+
+    <sys:String x:Key="Information.NoUpdate.Message">你正在使用最新的ModMyFactory。</sys:String>
+    <sys:String x:Key="Information.NoUpdate.Title">无可用更新</sys:String>
+
+    <sys:String x:Key="Error.RetrievingVersions.Message">无法获取可用异星工厂版本。</sys:String>
+    <sys:String x:Key="Error.RetrievingVersions.Title">错误</sys:String>
+
+    <sys:String x:Key="Error.InvalidFactorioArchive.Message">此ZIP压缩包不包含有效的异星工厂安装包。</sys:String>
+    <sys:String x:Key="Error.InvalidFactorioArchive.Title">无效压缩包</sys:String>
+
+    <sys:String x:Key="Question.DeleteFactorioArchive.Message">你确定要删除此文件吗？</sys:String>
+    <sys:String x:Key="Question.DeleteFactorioArchive.Title">删除？</sys:String>
+
+    <sys:String x:Key="Error.InvalidFactorioFolder.Message">此文件夹不包含有效的异星工厂安装包。</sys:String>
+    <sys:String x:Key="Error.InvalidFactorioFolder.Title">无效文件夹</sys:String>
+
+    <sys:String x:Key="Error.IncompatiblePlatform.Message">此版本的异星工厂与你的系统不匹配。&#x0a;在32位系统上使用32位异星工厂，在64位系统上使用64位异星工厂。</sys:String>
+    <sys:String x:Key="Error.IncompatiblePlatform.Title">系统不匹配</sys:String>
+    
+    <sys:String x:Key="Error.FactorioVersionInstalled.Message">此版本的异星工厂已经安装。</sys:String>
+    <sys:String x:Key="Error.FactorioVersionInstalled.Title">此版本已安装</sys:String>
+
+    <sys:String x:Key="Warning.MoveSteamFactorio.Message">所有的模组、游戏纪录与scenarios会被转移到设置的新文件夹里！强烈推荐备份现有文件。&#x0a;你希望继续吗？</sys:String>
+    <sys:String x:Key="Warning.MoveSteamFactorio.Title">警告</sys:String>
+    
+    <sys:String x:Key="Error.FactorioUpdaterCritical.Message">异星工厂升级器遇到了严重错误。&#x0a;你的异星工厂安装包有可能已损坏，所以需要重新安装。</sys:String>
+    <sys:String x:Key="Error.FactorioUpdaterCritical.Title">升级器严重错误</sys:String>
+    
+    <sys:String x:Key="Information.NoFactorioUpdate.Message">此异星工厂是最新版本。</sys:String>
+    <sys:String x:Key="Information.NoFactorioUpdate.Title">无可用更新</sys:String>
+
+    <sys:String x:Key="Question.RemoveFactorioVersion.Message">你确定要删除此版本的异星工厂吗？&#x0a;这会不可逆转地删除你硬盘上的所有相关文件。</sys:String>
+    <sys:String x:Key="Question.RemoveFactorioVersion.Title">确认</sys:String>
+    
+    <sys:String x:Key="Question.DeleteMod.Message">你确定要删除此模组吗？</sys:String>
+    <sys:String x:Key="Question.DeleteMod.Title">确认</sys:String>
+    
+    <sys:String x:Key="Question.DeleteMods.Message">你确定要删除所有已选中模组吗？</sys:String>
+    <sys:String x:Key="Question.DeleteMods.Title">确认</sys:String>
+    
+    <sys:String x:Key="Question.DeleteModpack.Message">你确定要删除此模组包吗？</sys:String>
+    <sys:String x:Key="Question.DeleteModpack.Title">确认</sys:String>
+    
+    <sys:String x:Key="Question.DeleteModpacks.Message">你确定要删除所有已选中模组包吗？</sys:String>
+    <sys:String x:Key="Question.DeleteModpacks.Title">确认</sys:String>
+
+
+    <!-- file type descriptions -->
+    <sys:String x:Key="ZipDescription">ZIP压缩包</sys:String>
+    <sys:String x:Key="LnkDescription">快捷方式</sys:String>
+    <sys:String x:Key="FmpDescription">异星工厂模组包</sys:String>
+
+
+    <!-- progress dialogs -->
+    <sys:String x:Key="MovingFilesDescription">正在移动文件……</sys:String>
+    <sys:String x:Key="CopyingFilesDescription">正在复制文件……</sys:String>
+    <sys:String x:Key="ExtractingDescription">正在解压文件……</sys:String>
+
+    <sys:String x:Key="FetchingModsAction">正在获取模组</sys:String>
+    <sys:String x:Key="ParsingFirstPageDescription">解析第 1 页。</sys:String>
+    <sys:String x:Key="ParsingPageDescription">解析第 {0} 页，共 {1} 页。</sys:String>
+
+    <sys:String x:Key="ProcessingModsAction">解析模组</sys:String>
+    <sys:String x:Key="ProcessingModAction">解析模组</sys:String>
+
+    <sys:String x:Key="SearchingForUpdatesAction">正在寻找更新</sys:String>
+    <sys:String x:Key="UpdatingModsAction">更新模组</sys:String>
+
+    <sys:String x:Key="MovingDirectoriesAction">正在移动文件夹</sys:String>
+
+    <sys:String x:Key="DownloadingAction">下载中</sys:String>
+    <sys:String x:Key="DownloadingDescription">正在下载{0}。</sys:String>
+
+    <sys:String x:Key="AddingFromZipAction">正在从ZIP压缩包中获取模组</sys:String>
+    <sys:String x:Key="CheckingValidityDescription">正在检查完整性……</sys:String>
+
+    <sys:String x:Key="AddingLocalInstallationAction">正在加入本地异星工厂安装包</sys:String>
+
+    <sys:String x:Key="AddingSteamVersionAction">正在加入Steam版本异星工厂</sys:String>
+
+    <sys:String x:Key="RemovingFactorioVersionAction">正在移除异星工厂安装包</sys:String>
+    <sys:String x:Key="DeletingFilesDescription">正在删除文件……</sys:String>
+
+    <sys:String x:Key="UpdatingAction">正在更新</sys:String>
+    
+    <sys:String x:Key="UpdatingFactorioAction">正在更新异星工厂</sys:String>
+    <sys:String x:Key="UpdatingFactorioStage1Description">正在下载更新包</sys:String>
+    <sys:String x:Key="UpdatingFactorioStage2Description">正在加载更新包</sys:String>
+
+
+
+    <!--
+    ____________________ Misc ____________________
+    -->
+
+    <!-- buttons -->
+    <sys:String x:Key="OkButton">确定</sys:String>
+    <sys:String x:Key="CloseButton">关闭</sys:String>
+    <sys:String x:Key="CancelButton">取消</sys:String>
+    <sys:String x:Key="DownloadButton">下载</sys:String>
+    <sys:String x:Key="UpdateButton">更新</sys:String>
+    <sys:String x:Key="ClearFilterToolTip">Clear Filter</sys:String>
+
+
+    <!--
+    ____________________ MainWindow ____________________
+    -->
+
+    <sys:String x:Key="MainWindowTitle">ModMyFactory</sys:String>
+
+    <!-- 'File' menu -->
+    <sys:String x:Key="FileMenuItem">文件（_F)</sys:String>
+    <sys:String x:Key="AddModsMenuItem">添加模组</sys:String>
+    <sys:String x:Key="DownloadModsMenuItem">下载模组</sys:String>
+    <sys:String x:Key="AddModFilesMenuItem">从文件加载</sys:String>
+    <sys:String x:Key="AddModFolderMenuItem">从文件夹加载</sys:String>
+    <sys:String x:Key="NewModpackMenuItem">新模组包</sys:String>
+    <sys:String x:Key="CreateLinkMenuItem">新建桌面快捷方式</sys:String>
+    <sys:String x:Key="ExportModpacksMenuItem">导出模组包</sys:String>
+    <sys:String x:Key="ImportModpacksMenuItem">导入模组包</sys:String>
+    <sys:String x:Key="StartGameMenuItem">开始游戏</sys:String>
+    <sys:String x:Key="CloseMenuItem">关闭</sys:String>
+
+    <!-- 'Edit' menu -->
+    <sys:String x:Key="EditMenuItem">编辑（_E）</sys:String>
+    <sys:String x:Key="UpdateModsMenuItem">更新模组</sys:String>
+    <sys:String x:Key="VersionManagerMenuItem">版本管理</sys:String>
+    <sys:String x:Key="SettingsMenuItem">设置</sys:String>
+    
+    <!-- 'View' menu -->
+    <sys:String x:Key="ViewMenuItem">查看（_V）</sys:String>
+    <sys:String x:Key="OpenFactorioFolderMenuItem">打开异星工厂文件夹</sys:String>
+    <sys:String x:Key="OpenModFolderMenuItem">打开模组文件夹</sys:String>
+    <sys:String x:Key="OpenSavegameFolderMenuItem">打开游戏纪录文件夹</sys:String>
+    <sys:String x:Key="OpenScenarioFolderMenuItem">打开scenario文件夹</sys:String>
+    <sys:String x:Key="RefreshMenuItem">刷新</sys:String>
+
+    <!-- 'Language' menu -->
+    <sys:String x:Key="LanguageMenuItem">语言（_L）</sys:String>
+
+    <!-- 'Info' menu -->
+    <sys:String x:Key="InfoMenuItem">信息（_I）</sys:String>
+    <sys:String x:Key="FactorioComMenuItem">Factorio.com</sys:String>
+    <sys:String x:Key="FactorioModsComMenuItem">Factoriomods.com</sys:String>
+    <sys:String x:Key="ForumThreadMenuItem">ModMyFactory论坛</sys:String>
+    <sys:String x:Key="CheckUpdateMenuItem">查找更新</sys:String>
+    <sys:String x:Key="AboutMenuItem">关于ModMyFactory</sys:String>
+    <sys:String x:Key="HelpMenuItem">帮助</sys:String>
+    
+    <!-- context menu -->
+    <sys:String x:Key="DeleteSelectedModsMenuItem">删除已选择模组</sys:String>
+    <sys:String x:Key="ActivateSelectedModsMenuItem">启用已选择模组</sys:String>
+    <sys:String x:Key="DeactivateSelectedModsMenuItem">停用已选择模组</sys:String>
+    <sys:String x:Key="SelectActiveModsMenuItem">选中所有已启用模组</sys:String>
+    <sys:String x:Key="SelectInactiveModsMenuItem">选中所有已停用模组</sys:String>
+    
+    <sys:String x:Key="DeleteSelectedModpacksMenuItem">删除已选择模组包</sys:String>
+    <sys:String x:Key="ActivateSelectedModpacksMenuItem">启用已选择模组包</sys:String>
+    <sys:String x:Key="DeactivateSelectedModpacksMenuItem">停用已选择模组包</sys:String>
+    <sys:String x:Key="SelectActiveModpacksMenuItem">选中所有已启用模组包</sys:String>
+    <sys:String x:Key="SelectInactiveModpacksMenuItem">选中所有已停用模组包</sys:String>
+    
+    <!-- headers -->
+    <sys:String x:Key="ModsHeader">模组</sys:String>
+    <sys:String x:Key="ModpacksHeader">模组包</sys:String>
+
+    <!-- tooltips -->
+    <sys:String x:Key="RenameToolTip">重命名</sys:String>
+    <sys:String x:Key="DeleteToolTip">删除</sys:String>
+    <sys:String x:Key="RemoveToolTip">从模组包移除</sys:String>
+    <sys:String x:Key="SetActiveToolTip">启用</sys:String>
+    <sys:String x:Key="SetInactiveToolTip">停用</sys:String>
+    <sys:String x:Key="SetAllActiveToolTip">启用所有</sys:String>
+    <sys:String x:Key="SetAllInactiveToolTip">停用所有</sys:String>
+
+
+    <!--
+    ____________________ VersionManagementWindow ____________________
+    -->
+
+    <sys:String x:Key="VersionManagementWindowTitle">版本管理器</sys:String>
+
+    <!-- buttons -->
+    <sys:String x:Key="AddZipButton">从ZIP压缩包导入</sys:String>
+    <sys:String x:Key="AddFolderButton">从文件夹导入</sys:String>
+    <TextBlock x:Key="SelectSteamButton" TextAlignment="Center">选择&#x0a;Steam版本</TextBlock>
+    <sys:String x:Key="OpenFolderButton">打开文件夹</sys:String>
+    <sys:String x:Key="RemoveButton">删除</sys:String>
+
+
+    <!--
+    ____________________ VersionListWindow ____________________
+    -->
+
+    <sys:String x:Key="VersionListWindowTitle">选择版本</sys:String>
+    
+    <!-- checkboxes -->
+    <sys:String x:Key="ShowExperimentalCheckBox">显示预览版</sys:String>
+    
+    <!-- tooltips -->
+    <sys:String x:Key="ExperimentalToolTip">预览版</sys:String>
+
+
+    <!--
+    ____________________ SettingsWindow ____________________
+    -->
+
+    <sys:String x:Key="SettingsWindowTitle">设置</sys:String>
+
+    <!-- tab headers -->
+    <sys:String x:Key="GeneralTabHeader">通用</sys:String>
+    <sys:String x:Key="LocationsTabHeader">位置</sys:String>
+    
+    <!-- group headers -->
+    <sys:String x:Key="ManagerModeGroupHeader">管理模式</sys:String>
+    <sys:String x:Key="MiscGroupHeader">杂项</sys:String>
+    <sys:String x:Key="CredentialsGroupHeader">登录密钥</sys:String>
+    
+    <sys:String x:Key="FactorioDirectoryGroupHeader">异星工厂地址</sys:String>
+    <sys:String x:Key="ModDirectoryGroupHeader">模组地址</sys:String>
+    <sys:String x:Key="SavegameDirectoryGroupHeader">游戏纪录地址</sys:String>
+    <sys:String x:Key="ScenarioDirectoryGroupHeader">scenario地址</sys:String>
+
+    <!-- group items -->
+    <sys:String x:Key="PerFactorioVersionGroupItem">按异星工厂版本</sys:String>
+    <sys:String x:Key="UpdateSearchGroupItem">在启动时搜索更新</sys:String>
+    <sys:String x:Key="IncludePreReleasesGroupItem">搜索更新时包含预览版</sys:String>
+    <sys:String x:Key="UpdateZippedGroupItem">模组更新为ZIP压缩包</sys:String>
+    <sys:String x:Key="KeepOldModVersionsGroupItem">更新时保留旧版本模组</sys:String>
+    <sys:String x:Key="KeepExtractedModVersionsGroupItem">更新时保留解压后的旧版本模组</sys:String>
+    <sys:String x:Key="KeepZippedModVersionsGroupItem">更新时保留未解压的旧版本模组</sys:String>
+    <sys:String x:Key="KeepOldWhenNewFactorioGroupItem">更新异星工厂版本时保留旧版本模组</sys:String>
+    <sys:String x:Key="UpdateIntermediateGroupItem">仍为旧版本异星工厂更新模组</sys:String>
+    <sys:String x:Key="GlobalGroupItem">全局</sys:String>
+    <sys:String x:Key="AppDataGroupItem">软件数据</sys:String>
+    <sys:String x:Key="AppDirectoryGroupItem">软件地址</sys:String>
+    <sys:String x:Key="SelectGroupItem">选择：</sys:String>
+
+    <!-- buttons -->
+    <sys:String x:Key="BrowseButton">浏览</sys:String>
+
+
+    <!--
+    ____________________ LoginWindow ____________________
+    -->
+
+    <sys:String x:Key="LoginWindowTitle">登录</sys:String>
+
+    <!-- headers -->
+    <sys:String x:Key="UsernameHeader">用户名或邮箱</sys:String>
+    <sys:String x:Key="PasswordHeader">密码</sys:String>
+    <sys:String x:Key="SaveCredentialsHeader">记住密码</sys:String>
+
+    <!-- messages -->
+    <sys:String x:Key="LoginFailedMessage">登录失败！</sys:String>
+
+
+    <!--
+    ____________________ LinkPropertiesWindow ____________________
+    -->
+
+    <sys:String x:Key="LinkPropertiesWindowTitle">选择快捷方式属性</sys:String>
+
+    <!-- headers -->
+    <sys:String x:Key="SelectFactorioHeader">选择异星工厂版本：</sys:String>
+    <sys:String x:Key="SelectModpackHeader">选择模组包：</sys:String>
+
+
+    <!-- buttons -->
+    <sys:String x:Key="CreateButton">新建</sys:String>
+    
+    
+    <!-- checkboxes -->
+    <sys:String x:Key="UseExactVersionCheckBox">使用完全相同的版本</sys:String>
+
+
+    <!--
+    ____________________ AboutWindow ____________________
+    -->
+
+    <sys:String x:Key="AboutWindowTitle">关于ModMyFactory</sys:String>
+
+
+    <!-- labels -->
+    <sys:String x:Key="AuthorLabel">作者：Mathis Rech</sys:String>
+    <sys:String x:Key="FlagsLabel">Flags图片：</sys:String>
+    <sys:String x:Key="FontLabel">异星工厂字体：</sys:String>
+    <sys:String x:Key="DialogsLabel">对话：</sys:String>
+    <sys:String x:Key="JsonLabel">JSON框架：</sys:String>
+    <sys:String x:Key="GitHubLabel">GitHub API：</sys:String>
+    <sys:String x:Key="ZlibLabel">CRC32具现化：</sys:String>
+    <sys:String x:Key="XdeltaLabel">VCDIFF具现化：</sys:String>
+
+    <!-- headers -->
+    <sys:String x:Key="ContributorsHeader">贡献者</sys:String>
+    <sys:String x:Key="TranslatorsHeader">翻译者</sys:String>
+
+    
+    <!--
+    ____________________ OnlineModsWindow ____________________
+    -->
+
+    <sys:String x:Key="OnlineModsWindowTitle">浏览在线模组</sys:String>
+
+    <!-- format strings -->
+    <sys:String x:Key="ByFormat">来自{0}</sys:String>
+
+    <!-- tooltips -->
+    <sys:String x:Key="ViewsToolTip">浏览</sys:String>
+    <sys:String x:Key="DownloadsToolTip">下载</sys:String>
+    <sys:String x:Key="InstalledToolTip">已安装</sys:String>
+    
+    <!-- labels -->
+    <sys:String x:Key="LicenseLabel">许可：</sys:String>
+    <sys:String x:Key="HomepageLabel">主页：</sys:String>
+    <sys:String x:Key="GitHubUrlLabel">GitHub：</sys:String>
+
+    <!-- headers -->
+    <sys:String x:Key="ReleasesHeader">版本</sys:String>
+    
+    <!-- buttons -->
+    <sys:String x:Key="DeleteButton">删除</sys:String>
+    <sys:String x:Key="RefreshButton">刷新</sys:String>
+
+
+    <!--
+    ____________________ ModUpdateWindow ____________________
+    -->
+
+    <sys:String x:Key="ModUpdateWindowTitle">选择要更新的模组</sys:String>
+
+    <!-- format strings -->
+    <sys:String x:Key="CurrentVersionFormat">目前版本：{0}</sys:String>
+    <sys:String x:Key="NewestVersionFormat">最新版本：{0}</sys:String>
+
+
+    <!--
+    ____________________ ModpackExportWindow ____________________
+    -->
+
+    <sys:String x:Key="ModpackExportWindowTitle">选择要导出的模组包</sys:String>
+
+    <!-- options -->
+    <sys:String x:Key="IncludeVersionInfoOption">包含版本信息</sys:String>
+
+    <!-- tooltips -->
+    <sys:String x:Key="IncludeVersionsToolTip">这会将导出的模组的版本保存在导出后的文件里。&#x0a;在导入的时候ModMyFactory会使用此信息来下载对应版本的模组。</sys:String>
+
+    <!-- buttons -->
+    <sys:String x:Key="ExportButton">导出</sys:String>
+    
+    
+    <!--
+    ____________________ UpdateListWindow ____________________
+    -->
+
+    <sys:String x:Key="UpdateListWindowTitle">选择目标版本</sys:String>
+    
+    
+    <!--
+    ____________________ CopyOrMoveMessageWindow ____________________
+    -->
+    
+    <sys:String x:Key="CopyOrMoveMessageWindowTitle">复制或者移动？</sys:String>
+    
+    <!-- messages -->
+    <sys:String x:Key="CopyOrMoveFactorioMessage">你想要复制还是移动此异星工厂安装包？&#x0a;选择移动将会删除现有安装包。</sys:String>
+    <sys:String x:Key="CopyOrMoveModsMessage">你想要复制还是移动所有已选择的模组？</sys:String>
+    <sys:String x:Key="CopyOrMoveModMessage">你想要复制还是移动当前已选择的模组？</sys:String>
+    
+    <!-- buttons -->
+    <sys:String x:Key="CopyButton">复制</sys:String>
+    <sys:String x:Key="MoveButton">移动</sys:String>
+
+</ResourceDictionary>


### PR DESCRIPTION
Known issue: "Scenario" not translated.
Unsure how to solve:
in Main Window column, the entry for "FileMenuItem", "EditMenuItem", "ViewMenuItem", "LanguageMenuItem", and "InfoMenuItem", (as an example I refer to FileMenuItem but it also applies to others that I mentioned), what would show up in the main window should be "文件（F）" without quotation marks, but it is using "F" as the shortcut the same as using English translation. I hope what I did does what I said, but I need confirmation about it.