### PR TITLE
Fix login issue with complex passwords

### DIFF
--- a/ModMyFactory/ModMyFactory/Helpers/SecureStringHelper.cs
+++ b/ModMyFactory/ModMyFactory/Helpers/SecureStringHelper.cs
@@ -129,9 +129,9 @@ namespace ModMyFactory.Helpers
         /// This method does not create any managed string objects.
         /// </summary>
         /// <param name="secureString">The SecureString object to fill the byte array from.</param>
-        public static void SecureStringToBytes(SecureString secureString)
+        public static byte[] SecureStringToBytes(SecureString secureString)
         {
-            SecureStringToBytes(secureString, Encoding.UTF8);
+            return SecureStringToBytes(secureString, Encoding.UTF8);
         }
 
         /// <summary>

--- a/ModMyFactory/ModMyFactory/ModMyFactory.csproj
+++ b/ModMyFactory/ModMyFactory/ModMyFactory.csproj
@@ -69,6 +69,7 @@
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Security" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />

--- a/ModMyFactory/ModMyFactory/Web/ApiAuthentication.cs
+++ b/ModMyFactory/ModMyFactory/Web/ApiAuthentication.cs
@@ -1,6 +1,8 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using System.Security;
 using System.Text;
+using System.Web;
 using ModMyFactory.Helpers;
 using ModMyFactory.Web.AuthenticationApi;
 
@@ -23,11 +25,13 @@ namespace ModMyFactory.Web
 
             string part1 = $"api_version=2&require_game_ownership=true&username={username}&password=";
             int part1Length = Encoding.UTF8.GetByteCount(part1);
-            int part2Length = SecureStringHelper.GetSecureStringByteCount(password);
 
-            byte[] content = new byte[part1Length + part2Length];
+            byte[] passwordBytes = SecureStringHelper.SecureStringToBytes(password);
+            string part2 = HttpUtility.UrlEncode(passwordBytes);
+
+            byte[] content = new byte[part1Length + part2.Length];
             Encoding.UTF8.GetBytes(part1, 0, part1.Length, content, 0);
-            SecureStringHelper.SecureStringToBytes(password, content, part1Length);
+            Encoding.UTF8.GetBytes(part2, 0, part2.Length, content, part1Length);
 
             try
             {


### PR DESCRIPTION
UrlEncodes the password, which is required when you have certain characters in your password (e.g. `&`, `^`, `?`).
Should work with any password, but I can't test that. It works on my PC I guess.

This commit does introduce a 'security issue' because the encoded password is stored in a managed string. You could work around that by using `HttpUtility.UrlEncodeToBytes` and `Buffer.BlockCopy` to merge the resulting arrays. In that case you won't have a managed string, I guess?

Feel free to deny this PR if you feel like this is an issue.

On an unrelated note, I would recommend not using SecureString in the future. I saw that you were rewriting this mod manager, so you could probably remove it there. [Why not use SecureString?](https://docs.microsoft.com/en-us/dotnet/api/system.security.securestring?view=netcore-3.1#remarks) Furthermore, Avalonia and .NET Core don't even support it. And it's a pain to use.